### PR TITLE
2021 03 05/vaccines hpi meta

### DIFF
--- a/data/infections-by-group/infections-by-group-california.json
+++ b/data/infections-by-group/infections-by-group-california.json
@@ -1,10 +1,85 @@
 {
   "meta": {
-    "PUBLISHED_DATE": "2021-03-04",
-    "METRIC_VALUE_VALID_RANGE" : {
-      "MINIMUM":0, 
-      "MAXIMUM":100  
-    }
+    "title": "Infections by group",
+    "published_date": "2021-03-04",
+    "administered_date": "",
+    "name": "california-infections-by-group",
+    "version": "v2.0.0",
+    "intent": "",
+    "description": "",
+    "tags": ["COVID-19"],
+    "groups": "",
+    "licenses": "",
+    "author": "",
+    "data_dictionary_type": "",
+    "data_dictionary": "",
+    "program_contact": "",
+    "public_access_level": "",
+    "topics": ["COVID-19"],
+    "language": "English",
+    "rights": "",
+    "homepage": "",
+    "data_standard": "",
+    "documentation_template": "",
+    "related_content": "",
+    "data_methodology": "",
+    "meta_updated": "2021-03-05T15:28:00.000Z",
+    "reference_files": "",
+    "edit_data_source_url": "",
+    "appears_on": ["https://staging.ca.gov/v2-state-dashboard"],
+    "contributors": "",
+    "metric": "",
+    "data_attributes": "",
+    "calculations": "",
+    "datasets": [
+      {
+        "name": "infections-by-group-california",
+        "data_service": "Snowflake",
+        "data_pipeline": "Snowflake > Github > FaaS HttpTrigger > \nJSON file\n",
+        "spatial_coverage": "Statewide",
+        "temporal_coverage": "",
+        "data_warehouse": "",
+        "database": "",
+        "table": "",
+        "data_query": "",
+        "data_location": "",
+        "review_data_location": "",
+        "version": "v2.0.0",
+        "metadata": "california-infections-by-group",
+        "fields": {
+          "validation_schema": {
+            "METRIC_VALUE": {
+              "minimum": 0,
+              "maximum": 100
+            }
+          },
+          "labels": {
+            "age": {
+              "0-17": "0-17",
+              "18-49": "18-49",
+              "50-64": "50-64",
+              "65+": "65+",
+              "Missing": "Missing"
+            },
+            "gender": {
+              "Female": "Female",
+              "Male": "Male",
+              "Unknown": "Unknown"
+            },
+            "race_and_ethnicity": {
+              "American Indian or Alaska Native": "American Indian or Alaska Native",
+              "Asian": "Asian",
+              "Black": "Black",
+              "Latino": "Latino",
+              "Multi-race": "Multi-race",
+              "Native Hawaiian and other Pacific Islander": "Native Hawaiian and other Pacific Islander",
+              "Other": "Other",
+              "White": "White"
+            }
+          }
+        }
+      }
+    ]
   },
   "data": {
     "by_race_and_ethnicity": {

--- a/data/vaccine-hpi/vaccine-hpi.json
+++ b/data/vaccine-hpi/vaccine-hpi.json
@@ -1,7 +1,68 @@
 {
   "meta": {
-    "LATEST_ADMINISTERED_DATE": "2021-03-05",
-    "PUBLISHED_DATE": "2021-03-05"
+    "title": "Vaccines, Healthy Places Index (HPI)",
+    "published_date": "2021-03-05",
+    "administered_date": "2021-03-05",
+    "name": "vaccines-hpi",
+    "version": "v2.0.0",
+    "intent": "",
+    "description": "",
+    "tags": ["COVID-19"],
+    "groups": "",
+    "licenses": "",
+    "author": "",
+    "data_dictionary_type": "",
+    "data_dictionary": "",
+    "program_contact": "",
+    "public_access_level": "",
+    "topics": ["COVID-19"],
+    "language": "English",
+    "rights": "",
+    "homepage": "",
+    "data_standard": "",
+    "documentation_template": "",
+    "related_content": "",
+    "data_methodology": "",
+    "meta_updated": "2021-03-05T15:28:00.000Z",
+    "reference_files": "",
+    "edit_data_source_url": "",
+    "appears_on": ["https://staging.ca.gov/v2-state-dashboard"],
+    "contributors": "",
+    "metric": "",
+    "data_attributes": "",
+    "calculations": "",
+    "datasets": [
+      {
+        "name": "VaccineHPI",
+        "label": "Healthy Places Index (HPI) Vaccine data showing infections by group.",
+        "data_service": "Snowflake",
+        "data_pipeline": "Snowflake > Github > FaaS HttpTrigger > \nJSON file\n",
+        "spatial_coverage": "Statewide",
+        "temporal_coverage": "",
+        "data_warehouse": "VWH_CA_VACCINE",
+        "database": "CA_VACCINE",
+        "table": "CA_VACCINE.VW_TAB_INT_ALL",
+        "data_query": "https://github.com/cagov/Cron/tree/master/common/SQL/CDTCDPH_VACCINE/vaccine_hpi",
+        "data_location": "https://files.covid19.ca.gov/data/vaccine-hpi/vaccine-hpi.json.",
+        "review_data_location": "",
+        "version": "v2.0.0",
+        "metadata": "Infections by group",
+        "fields": {
+          "validation_schema": {
+          },
+          "labels": {
+            "HPIQUARTILE": "Quartile",
+            "AGE16_POPULATION": "Age 16",
+            "FIRST_DOSE": "First dose",
+            "COMPLETED_DOSE": "Completed dose",
+            "COMBINED_DOSES": "Combined doses",
+            "FIRST_DOSE_RATIO": "First dose ratio",
+            "COMPLETED_DOSE_RATIO": "Completed dose ratio",
+            "COMBINED_DOSES_RATIO": "Combined dose ratio",
+          }
+        }
+      }
+    ]
   },
   "data": [
     {


### PR DESCRIPTION
Add meta content to vaccine HPI. Included a spot for validation & human readable versions of the labels though I didn't look up how they are displayed. Think I got the info correct, but let'ssee how it is to fill in this info - we can also update our airtable data documentation database via reading a JSON file & then re-write that info to our covid19 data package (if it turns out that this JSON format is easier to use.