### PR TITLE
Added support for prerendering postvax charts.

### DIFF
--- a/.github/workflows/svg-pregen.yml
+++ b/.github/workflows/svg-pregen.yml
@@ -12,11 +12,12 @@ jobs:
       - run: |
           git pull
           npm install
-          npm run sparklines
+          npm run svgPregen
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add img/generated/sparklines/*
-          git commit -m "generated sparklines"
+          git add img/generated/postvax/*
+          git commit -m "generated sparklines and postvax charts"
           git push origin master
       - uses: StateOfCalifornia/azblob-upload-artifact@master     
         with:

--- a/img/generated/sparklines/date-ran.txt
+++ b/img/generated/sparklines/date-ran.txt
@@ -1,1 +1,1 @@
-Mon Sep 20 2021 22:31:06 GMT+0000 (Coordinated Universal Time)
+Mon Sep 20 2021 17:14:04 GMT-0700 (Pacific Daylight Time)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "move": "node src/move.js",
     "updateSitemap": "node src/updateSitemap.js",
-    "sparklines": "node src/svg-pregen.js"
+    "svgPregen": "node src/svg-pregen.js"
   },
   "repository": {
     "type": "git",

--- a/src/svg-pregen.js
+++ b/src/svg-pregen.js
@@ -29,6 +29,16 @@ function writeFile(file, filecontent) {
 
   const sparklineTests = await page.$eval("cagov-chart-dashboard-sparkline[data-chart-config-key='tests'] svg", el => el.outerHTML);
   writeFile('./img/generated/sparklines/sparkline-tests.svg',sparklineTests);
-  
+
+  const postvaxCases = await page.$eval("cagov-chart-dashboard-postvax-chart-prerender[data-chart-config-key='cases'] svg", el => el.outerHTML);
+  writeFile('./img/generated/postvax/postvax-cases.svg',postvaxCases);
+
+  const postvaxDeaths = await page.$eval("cagov-chart-dashboard-postvax-chart-prerender[data-chart-config-key='deaths'] svg", el => el.outerHTML);
+  writeFile('./img/generated/postvax/postvax-deaths.svg',postvaxDeaths);
+
+  const postvaxHospitalizations = await page.$eval("cagov-chart-dashboard-postvax-chart-prerender[data-chart-config-key='hospitalizations'] svg", el => el.outerHTML);
+  writeFile('./img/generated/postvax/postvax-hospitalizations.svg',postvaxHospitalizations);
+
+
   await browser.close();
 })();


### PR DESCRIPTION
I've added the three postvax charts to covid19 /state-dashboard-sparklines/.  
(future todo: fix this directory name to be more generic -- it's not just sparklines anymore).

This modifies covid-static to capture those as well.

I've also changed the npm task name from 'sparklines' to 'svgPregen'

Not sure how to test this end-to-end locally... but I've tested via **npm run svgPregen**
