### PR TITLE
Postpone chart update to 9:25.

### DIFF
--- a/.github/workflows/svg-pregen.yml
+++ b/.github/workflows/svg-pregen.yml
@@ -2,7 +2,7 @@ name: SVG pregeneration
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '15 16 * * *'
+    - cron:  '20 16 * * *'
       
 jobs:
   build:


### PR DESCRIPTION
As part of pipeline tightening, we are writing json data to preproduction branch in covid-static-data, and then doing a single merge to master at 9:20. 

Postponing this action to 9:25 when we expect the data to be ready (this may still be a bit early, in which case, I'll push it later, after tomorrow's rollout).


