### PR TITLE
Added workflow for upload to s3/cloudfront.

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -19,7 +19,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
-          SOURCE_DIR: ./pdfs # only move built directory
+          SOURCE_DIR: ./pdf # only move built directory
           DEST_DIR: ./pdf # only move built directory
 
       - name: Deploy to S3 (img)


### PR DESCRIPTION
Workflow for uploading to S3 and invalidating cache on Cloudfront.

Similar to the azure-blob workflow, three different directories are being uploaded: ./pdfs ./img ./data
The s3-sync-action module does not appear to support multiple directory specification, so I am uploading
each directory in sequence.

I am unclear at this point if the --delete flag will be an issue. I am _expecting_ it to delete files in the ./data directory
only, when the ./data directory is synced.  If it deletes everything, we will need to modify this script to only use the --delete flag on the first directory in the sequence.