### PR TITLE
Jbum sitemap fix

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -15,31 +15,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - run: mkdir -p path/to/artifact/data
+      - run: HOMEDIR=$HOME npm run updateSitemap
 
-      # Push built site files to S3 production bucket (static)
-      - name: Deploy to S3 (PDFs -> static)
+      # Push the site map to S3 data (do not delete other files)
+      - name: Deploy to S3 (PDFs)
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --acl public-read --follow-symlinks 
         env:
-          AWS_S3_BUCKET: 'static.covid19.ca.gov'
+          AWS_S3_BUCKET: 'data.covid19.ca.gov'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-west-1'
-          SOURCE_DIR: ./pdf
-          DEST_DIR: pdf
+          SOURCE_DIR: ./path/to/artifact/data/sitemap.xml
+          DEST_DIR: data
 
-      - name: Deploy to S3 (img -> static)
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl public-read --follow-symlinks --delete
+      #
+      # Invalidate Cloudfront production distribution for (data)
+      - name: invalidate
+        uses: chetan/invalidate-cloudfront-action@v1.3
         env:
-          AWS_S3_BUCKET: 'static.covid19.ca.gov'
+          DISTRIBUTION: 'EHNPIZWYYWA31'
+          PATHS: '/data/* /data'
+          AWS_REGION: 'us-west-1'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-west-1'
-          SOURCE_DIR: ./img
-          DEST_DIR: img
 
       # Push built site files to S3 production bucket (files)
       - name: Deploy to S3 (PDFs -> files)
@@ -65,18 +66,6 @@ jobs:
           AWS_REGION: 'us-west-1'
           SOURCE_DIR: ./img
           DEST_DIR: img
-
-
-      #
-      # Invalidate Cloudfront production distribution for static.covid19.ca.gov/pdf
-      - name: invalidate
-        uses: chetan/invalidate-cloudfront-action@v1.3
-        env:
-          DISTRIBUTION: 'E2JUQO39Z38NB3'
-          PATHS: '/pdf /pdf/* /img /img/*'
-          AWS_REGION: 'us-west-1'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       #
       # Invalidate Cloudfront production distribution for files.covid19.ca.gov/pdf

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -18,29 +18,18 @@ jobs:
       - run: mkdir -p path/to/artifact/data
       - run: HOMEDIR=$HOME npm run updateSitemap
 
-      # Push the site map to S3 data (do not delete other files)
+      # Push the site map to S3 data
       - name: Deploy to S3 (PDFs)
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl public-read --follow-symlinks 
+          args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: 'data.covid19.ca.gov'
+          AWS_S3_BUCKET: 'files.covid19.ca.gov'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-west-1'
           SOURCE_DIR: ./path/to/artifact/data/sitemap.xml
           DEST_DIR: data
-
-      #
-      # Invalidate Cloudfront production distribution for (data)
-      - name: invalidate
-        uses: chetan/invalidate-cloudfront-action@v1.3
-        env:
-          DISTRIBUTION: 'EHNPIZWYYWA31'
-          PATHS: '/data/* /data'
-          AWS_REGION: 'us-west-1'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       # Push built site files to S3 production bucket (files)
       - name: Deploy to S3 (PDFs -> files)
@@ -73,7 +62,7 @@ jobs:
         uses: chetan/invalidate-cloudfront-action@v1.3
         env:
           DISTRIBUTION: 'E21D0URMALUUJ4'
-          PATHS: '/pdf /pdf/* /img /img/*'
+          PATHS: '/pdf /pdf/* /img /img/* /data /data/*'
           AWS_REGION: 'us-west-1'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Adding writing of sitemap to files.covid19 (now pointing to S3/Cloudfront).

Note that MOST files in /data/ are now being written by covid-static-data, and go to a different distro.  The only files.covid19.ca.gov/data/ file will be this sitemap for now.  

